### PR TITLE
comment out a forgotten `browser()` call

### DIFF
--- a/R/eco.R
+++ b/R/eco.R
@@ -458,7 +458,7 @@ estimate.re <- function(adata, idata, mod, alpha.c, alpha, beta, sig)
         }
         else idi <- NULL
         allgroups <- 1
-browser()
+# browser()
         optfn <- function(U) -( sum ( lik.eco.fixed(U, aggi, indivi, adi, idi, mod, allgroups,
                                                     alpha.c, alpha, beta, sig, d=0, give.log=TRUE) ) # - log likelihood
                                + dnorm(U, log=TRUE) )


### PR DESCRIPTION
Hi,

there is a forgotten `browser` call in the `estimate.re` function. This is pretty annoying when actually running the code, so it should be removed.  